### PR TITLE
Update repository and domain configuration for mattblogsit.com

### DIFF
--- a/.github/branch-protection.md
+++ b/.github/branch-protection.md
@@ -46,7 +46,7 @@ This document outlines the recommended branch protection settings for the `main`
 
 ```bash
 # Enable branch protection for main branch
-gh api repos/mattgrif/mattblogsit-dev/branches/main/protection \
+gh api repos/MattBlogsIT/mattblogsit-blog/branches/main/protection \
   --method PUT \
   --field required_status_checks='{"strict":true,"contexts":["CI/CD Pipeline / Code Quality & Security","CI/CD Pipeline / Build Validation","CI/CD Pipeline / Integration Tests","PR Preview Build & Test / build-and-test"]}' \
   --field enforce_admins=true \
@@ -63,7 +63,7 @@ Create `.github/settings.yml` for use with the Settings app:
 
 ```yaml
 repository:
-  name: mattblogsit-dev
+  name: mattblogsit-blog
   description: Personal blog focused on IT, Cloud, and Cybersecurity topics
   private: false
   has_issues: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This is a personal blog focused on IT, Cloud, and Cybersecurity topics built wit
 
 ## Key Technical Details
 - **Framework**: Jekyll 3.10.0 (GitHub Pages compatible)
-- **Hosting**: GitHub Pages (https://mattgrif.github.io/mattblogsit-dev)
+- **Hosting**: GitHub Pages (https://mattblogsit.com)
 - **Theme**: Custom accessible theme with light/dark mode support
 - **Languages**: HTML, CSS, JavaScript, Liquid templating
 - **Plugins**: jekyll-feed, jekyll-sitemap (must be GitHub Pages safe)
@@ -151,7 +151,7 @@ tags:
 bundle exec jekyll serve --baseurl ""
 
 # Production build testing (CRITICAL - CI/CD enforces this)
-JEKYLL_ENV=production bundle exec jekyll build --baseurl "/mattblogsit-dev"
+JEKYLL_ENV=production bundle exec jekyll build --baseurl ""
 
 # Check for broken links
 bundle exec htmlproofer ./_site
@@ -227,9 +227,9 @@ When working on this blog:
 - No personal data collection - anonymous usage only
 
 **Google Search Console Integration:**
-1. Add property for `https://mattgrif.github.io/mattblogsit-dev`
+1. Add property for `https://mattblogsit.com`
 2. Verify ownership via Analytics property (automatic)
-3. Submit sitemap: `https://mattgrif.github.io/mattblogsit-dev/sitemap.xml`
+3. Submit sitemap: `https://mattblogsit.com/sitemap.xml`
 4. Enable GA4 + Search Console data linking
 
 **Analytics Dashboard Access:**

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+mattblogsit.com

--- a/_config.yml
+++ b/_config.yml
@@ -3,8 +3,8 @@ title: Matt Blogs IT
 description: >-
   A blog about IT, technology, and life by Matt Griffin.
   Systems Architect passionate about technology, volunteering, and adaptive sports.
-baseurl: "/mattblogsit-dev"
-url: "https://mattgrif.github.io"
+baseurl: ""
+url: "https://mattblogsit.com"
 
 # Analytics
 google_analytics_id: G-XPX6WGJE8W

--- a/enhancements.md
+++ b/enhancements.md
@@ -23,7 +23,7 @@ This document outlines the enhancement tasks for optimizing the Matt Blogs IT Je
   ```
   User-agent: *
   Allow: /
-  Sitemap: https://mattgrif.github.io/mattblogsit-dev/sitemap.xml
+  Sitemap: https://mattblogsit.com/sitemap.xml
   ```
 
 - [ ] **Implement structured data**

--- a/robots.txt
+++ b/robots.txt
@@ -13,7 +13,7 @@ Disallow: /vendor/
 Disallow: /node_modules/
 
 # Sitemap location
-Sitemap: https://mattgrif.github.io/mattblogsit-dev/sitemap.xml
+Sitemap: https://mattblogsit.com/sitemap.xml
 
 # Crawl delay (optional - be nice to servers)
 Crawl-delay: 1


### PR DESCRIPTION
## Summary
- Migrated repository from `mattgrif/mattblogsit-dev` to `MattBlogsIT/mattblogsit-blog`
- Configured custom domain `mattblogsit.com` for GitHub Pages hosting
- Updated all hardcoded references to use new repository and domain

## Changes Made
1. **Created CNAME file** - Required for GitHub Pages custom domain recognition
2. **Updated _config.yml**:
   - Changed `baseurl` from `/mattblogsit-dev` to `""` (empty for custom domain)
   - Changed `url` from `https://mattgrif.github.io` to `https://mattblogsit.com`
3. **Updated documentation and configuration files**:
   - robots.txt - Updated sitemap URL
   - CLAUDE.md - Updated hosting URL and build commands
   - .github/branch-protection.md - Updated repository paths
   - enhancements.md - Updated example sitemap URL

## Next Steps After Merge
1. Configure DNS records at your domain registrar:
   - Add A records pointing to GitHub Pages IPs (185.199.108.153, 185.199.109.153, 185.199.110.153, 185.199.111.153)
   - Or add CNAME record pointing to `MattBlogsIT.github.io`
2. Update Google Search Console with new domain property
3. Verify HTTPS certificate is issued (automatic via GitHub Pages)

## Test Plan
- [x] All files updated with correct URLs and paths
- [x] PR build validation passes
- [ ] Site loads correctly at custom domain after DNS propagation
- [ ] All internal links work with new baseurl configuration

🤖 Generated with [Claude Code](https://claude.ai/code)