### PR TITLE
Fix baseurl references for custom domain

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -60,7 +60,7 @@ bundle install
 bundle exec jekyll serve --baseurl ""
 
 # Test production build
-JEKYLL_ENV=production bundle exec jekyll build --baseurl "/mattblogsit-dev"
+JEKYLL_ENV=production bundle exec jekyll build --baseurl ""
 ```
 
 ## Workflow Permissions

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Build Jekyll site
         run: |
           echo "🔨 Building production site..."
-          bundle exec jekyll build --baseurl "/mattblogsit-dev"
+          bundle exec jekyll build --baseurl ""
           echo "✅ Production build complete"
         env:
           JEKYLL_ENV: production

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -80,7 +80,7 @@ jobs:
           done
 
       - name: Build Jekyll site for preview
-        run: bundle exec jekyll build --baseurl "/mattblogsit-dev/pr-${{ github.event.number }}"
+        run: bundle exec jekyll build --baseurl "/pr-${{ github.event.number }}"
         env:
           JEKYLL_ENV: production
 

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -26,8 +26,8 @@
             
             // Load search data if not already loaded
             if (posts.length === 0) {
-                // Use relative path that works with GitHub Pages
-                const basePath = window.location.pathname.includes('/mattblogsit-dev') ? '/mattblogsit-dev' : '';
+                // Use relative path that works with GitHub Pages and custom domain
+                const basePath = '';
                 fetch(basePath + '/search.json')
                     .then(response => {
                         if (!response.ok) {


### PR DESCRIPTION
## Summary
- Fixes CSS and JavaScript loading issues on mattblogsit.com
- Removes hardcoded `/mattblogsit-dev` references that were breaking asset loading

## Problem
After migrating to the custom domain, the site was still trying to load assets from `/mattblogsit-dev/` paths, causing CSS and JavaScript files to return 404 errors.

## Solution
Updated all remaining hardcoded baseurl references:
1. **GitHub Actions workflows** - Changed `--baseurl "/mattblogsit-dev"` to `--baseurl ""`
2. **search.js** - Removed conditional baseurl logic, now uses root path
3. **PR preview workflow** - Simplified preview path from `/mattblogsit-dev/pr-*` to `/pr-*`

## Test Plan
- [x] All baseurl references updated
- [ ] PR build validation passes
- [ ] After merge, verify CSS and JS load correctly on mattblogsit.com
- [ ] Verify search functionality works on custom domain

## Files Changed
- `.github/workflows/ci-cd.yml` - Production build command
- `.github/workflows/pr-preview.yml` - PR preview build command
- `.github/workflows/README.md` - Documentation update
- `assets/js/search.js` - Remove hardcoded path logic

🤖 Generated with [Claude Code](https://claude.ai/code)