### PR TITLE
Fix workflow to handle existing branches

### DIFF
--- a/.github/workflows/issue-to-post.yml
+++ b/.github/workflows/issue-to-post.yml
@@ -91,7 +91,13 @@ jobs:
           git config --local user.name "GitHub Action"
           
           # Create and checkout new branch
-          git checkout -b blog-post/issue-${{ github.event.issue.number }}
+          BRANCH_NAME="blog-post/issue-${{ github.event.issue.number }}"
+          
+          # Delete the branch if it exists (from previous failed runs)
+          git push origin --delete $BRANCH_NAME 2>/dev/null || true
+          
+          # Create fresh branch
+          git checkout -b $BRANCH_NAME
           
           # Add the new blog post file
           git add _posts/${{ steps.create-post.outputs.filename }}
@@ -102,7 +108,7 @@ jobs:
           Generated from issue #${{ github.event.issue.number }}"
           
           # Push the branch
-          git push origin blog-post/issue-${{ github.event.issue.number }}
+          git push origin $BRANCH_NAME
           
       - name: Convert issue to pull request
         uses: actions/github-script@v7


### PR DESCRIPTION
## Problem
The workflow was failing with two issues:
1. **Permission error**: "GitHub Actions is not permitted to create or approve pull requests"
2. **Push rejection**: "failed to push some refs" when branch already exists from previous runs

## Solution
### Issue 1: Permission Error
- This requires enabling "Allow GitHub Actions to create and approve pull requests" in repository Settings > Actions > General
- You've already done this ✅

### Issue 2: Existing Branch
- Added cleanup step to delete existing branch before creating new one
- Uses `git push origin --delete $BRANCH_NAME 2>/dev/null || true` to safely remove old branches
- Prevents conflicts when workflow is re-run after failures

## Changes
- Delete existing branch from previous failed runs before creating fresh branch
- This ensures clean state for each workflow run

## Testing
After this fix:
1. The workflow should handle re-runs gracefully
2. No more "failed to push" errors
3. Successfully creates PR even if previous attempts failed